### PR TITLE
Fixed Square Color3 applying issue

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -271,7 +271,7 @@ Drawing.new = function(Type, UI)
                     SquareProperties.Size = Value
                 end
                 if (Property == "Color") then
-                    SquareFrame.TextColor3 = Value
+                    SquareFrame.BackgroundColor3 = Value
                     SquareProperties.Color = Value
                 end
                 if (Property == "Transparency") then


### PR DESCRIPTION
the square object had an issue where an attempt to set the color would edit TextColor3 instead of BackgroundColor3 resulting in an error